### PR TITLE
feat: add custom tools support

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ According to the docs, the following types are allowed in `responses.Request.Inp
   - `output.WebSearchCall`
   - `output.FunctionCall`
   - `output.FunctionCallOutput`
+  - `output.CustomToolCall`
+  - `output.CustomToolCallOutput`
   - `output.Reasoning`
   - `output.MCPListTools`
   - `output.MCPApprovalRequest`
@@ -221,6 +223,7 @@ Possible output types in the `responses.Response.ParsedOutputs` slice are:
   - `output.Refusal`
 - `output.FileSearchCall`
 - `output.FunctionCall`
+- `output.CustomToolCall`
 - `output.WebSearchCall`
 - `output.ComputerCall`
 - `output.Reasoning`
@@ -240,6 +243,7 @@ You can simply iterate over the outputs and type-assert each, but also there are
 - `Response.FirstText() string` returns the first text output in the response, or an empty string if there are no text outputs.
 - `Response.LastText() string` returns the last text output in the response, or an empty string if there are no text outputs.
 - `Response.FunctionCalls() []output.FunctionCall` returns all function calls from the response's top level.
+- `Response.CustomToolCalls() []output.CustomToolCall` returns all custom tool calls from the response's top level.
 - `Response.Refusals() []string` returns all refusals texts from output messages.
 
 ### Chaining requests with PreviousResponseID

--- a/client_test.go
+++ b/client_test.go
@@ -395,21 +395,11 @@ func TestClient_Responses_CustomToolAuto(t *testing.T) {
 	require.NotEmpty(t, resp)
 	require.NotEmpty(t, resp.ID)
 	require.NotEmpty(t, resp.ParsedOutputs)
-	toolCalled := false
-	for _, o := range resp.ParsedOutputs {
-		toolCall, ok := o.(output.CustomToolCall)
-		if !ok {
-			t.Logf("output of type %T when expected output.CustomToolCall: %#v", o, o)
-			continue
-		}
-
-		toolCalled = true
-		require.Equal(t, "submit_word", toolCall.Name)
-		require.NotEmpty(t, toolCall.Input)
-		t.Logf("tool called with input: %s", toolCall.Input)
-		break
-	}
-	require.True(t, toolCalled, "expected tool to be called")
+	toolCalls := resp.CustomToolCalls()
+	require.Len(t, toolCalls, 1)
+	require.Equal(t, "submit_word", toolCalls[0].Name)
+	require.NotEmpty(t, toolCalls[0].Input)
+	t.Logf("tool called with input: %s", toolCalls[0].Input)
 }
 
 func TestClient_Responses_CustomToolRegex(t *testing.T) {
@@ -439,21 +429,11 @@ func TestClient_Responses_CustomToolRegex(t *testing.T) {
 	require.NotEmpty(t, resp)
 	require.NotEmpty(t, resp.ID)
 	require.NotEmpty(t, resp.ParsedOutputs)
-	toolCalled := false
-	for _, o := range resp.ParsedOutputs {
-		toolCall, ok := o.(output.CustomToolCall)
-		if !ok {
-			t.Logf("output of type %T when expected output.CustomToolCall: %#v", o, o)
-			continue
-		}
-
-		toolCalled = true
-		require.Equal(t, "submit_word", toolCall.Name)
-		require.NotEmpty(t, toolCall.Input)
-		t.Logf("tool called with input: %s", toolCall.Input)
-		break
-	}
-	require.True(t, toolCalled, "expected tool to be called")
+	toolCalls := resp.CustomToolCalls()
+	require.Len(t, toolCalls, 1)
+	require.Equal(t, "submit_word", toolCalls[0].Name)
+	require.NotEmpty(t, toolCalls[0].Input)
+	t.Logf("tool called with input: %s", toolCalls[0].Input)
 }
 
 func TestClient_Responses_Stream(t *testing.T) {

--- a/content/output/output.go
+++ b/content/output/output.go
@@ -671,7 +671,7 @@ type CustomToolCallOutput struct {
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-// It fills in the "type" field with "custom_tool_output", discarding any prior value.
+// It fills in the "type" field with "custom_tool_call_output", discarding any prior value.
 func (c CustomToolCallOutput) MarshalJSON() ([]byte, error) {
 	c.Type = "custom_tool_call_output"
 	type alias CustomToolCallOutput

--- a/content/output/output.go
+++ b/content/output/output.go
@@ -65,6 +65,10 @@ func (a *Any) Unmarshal() (any, error) {
 		return unmarshalToType[FunctionCall](a)
 	case "function_call_output":
 		return unmarshalToType[FunctionCallOutput](a)
+	case "custom_tool_call":
+		return unmarshalToType[CustomToolCall](a)
+	case "custom_tool_call_output":
+		return unmarshalToType[CustomToolCallOutput](a)
 	case "reasoning":
 		return unmarshalToType[Reasoning](a)
 	case "mcp_list_tools":
@@ -627,6 +631,51 @@ func (f FunctionCallOutput) MarshalJSON() ([]byte, error) {
 	f.Type = "function_call_output"
 	type alias FunctionCallOutput
 	return openai.Marshal(alias(f))
+}
+
+// CustomToolCall describes a use of a custom tool call.
+type CustomToolCall struct {
+	// required
+
+	Type   string `json:"type"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Input  string `json:"input"`
+	Status string `json:"status"`
+
+	// optional
+
+	CallID string `json:"call_id,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// It fills in the "type" field with "custom_tool_call", discarding any prior value.
+func (c CustomToolCall) MarshalJSON() ([]byte, error) {
+	c.Type = "custom_tool_call"
+	type alias CustomToolCall
+	return openai.Marshal(alias(c))
+}
+
+// CustomToolCallOutput describes the output of a custom tool call.
+type CustomToolCallOutput struct {
+	// required
+
+	Type   string `json:"type"`
+	CallID string `json:"call_id"`
+	Output string `json:"output"`
+
+	// optional
+
+	ID     string `json:"id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// It fills in the "type" field with "custom_tool_output", discarding any prior value.
+func (c CustomToolCallOutput) MarshalJSON() ([]byte, error) {
+	c.Type = "custom_tool_call_output"
+	type alias CustomToolCallOutput
+	return openai.Marshal(alias(c))
 }
 
 // Reasoning describes model's internal thinking process.

--- a/examples/responses/streaming/main.go
+++ b/examples/responses/streaming/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/unkn0wncode/openai"
 	"github.com/unkn0wncode/openai/models"
@@ -18,6 +19,7 @@ func main() {
 	}
 
 	client := openai.NewClient(token)
+	client.Config().HTTPClient.Timeout = 60 * time.Second
 
 	req := &responses.Request{
 		Model:  models.DefaultNano,

--- a/examples/responses/tools/custom/auto/main.go
+++ b/examples/responses/tools/custom/auto/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	req := responses.Request{
-		Model: models.GPT5,
+		Model: models.GPT5Mini,
 		Input: "Search for golang tips using the notes_search tool and summarize what you find.",
 		Tools: []string{"notes_search"},
 	}

--- a/examples/responses/tools/custom/auto/main.go
+++ b/examples/responses/tools/custom/auto/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/unkn0wncode/openai"
+	"github.com/unkn0wncode/openai/models"
+	"github.com/unkn0wncode/openai/responses"
+	"github.com/unkn0wncode/openai/tools"
+)
+
+// Example: automatic custom tool execution using Responses API.
+func main() {
+	token := os.Getenv("OPENAI_API_KEY")
+	if token == "" {
+		panic("set OPENAI_API_KEY env var")
+	}
+
+	client := openai.NewClient(token)
+
+	notes := map[string]string{
+		"golang":    "Prefer clear names. Avoid deep nesting. Handle errors early.",
+		"responses": "Custom tools can execute actions and return outputs back to the model.",
+		"release":   "Run tests, check lints, update README, tag release.",
+	}
+
+	if err := client.Config().Tools.RegisterTool(tools.Tool{
+		Type:        "custom",
+		Name:        "notes_search",
+		Description: "Searches project notes by keyword.",
+		Custom: func(input string) (string, error) {
+			query := strings.ToLower(strings.TrimSpace(input))
+			if content, found := notes[query]; found {
+				return fmt.Sprintf("Found note '%s': %s", query, content), nil
+			}
+			return fmt.Sprintf("No note found for '%s'. Available: %v", query, getKeys(notes)), nil
+		},
+	}); err != nil {
+		panic(err)
+	}
+
+	req := responses.Request{
+		Model: models.GPT5,
+		Input: "Search for golang tips using the notes_search tool and summarize what you find.",
+		Tools: []string{"notes_search"},
+	}
+
+	resp, err := client.Responses.Send(&req)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Response:", resp.JoinedTexts())
+}
+
+func getKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/examples/responses/tools/custom/auto/main.go
+++ b/examples/responses/tools/custom/auto/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 
@@ -35,7 +36,7 @@ func main() {
 			if content, found := notes[query]; found {
 				return fmt.Sprintf("Found note '%s': %s", query, content), nil
 			}
-			return fmt.Sprintf("No note found for '%s'. Available: %v", query, getKeys(notes)), nil
+			return fmt.Sprintf("No note found for '%s'. Available: %v", query, maps.Keys(notes)), nil
 		},
 	}); err != nil {
 		panic(err)
@@ -53,12 +54,4 @@ func main() {
 	}
 
 	fmt.Println("Response:", resp.JoinedTexts())
-}
-
-func getKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }

--- a/examples/responses/tools/custom/lark/main.go
+++ b/examples/responses/tools/custom/lark/main.go
@@ -30,6 +30,7 @@ func main() {
 		Description: "Evaluates arithmetic expressions.",
 		Format:      larkFormat,
 		Custom: func(input string) (string, error) {
+			fmt.Println("Tool called with input:", input)
 			return fmt.Sprintf("evaluated: %s", input), nil
 		},
 	}); err != nil {
@@ -37,7 +38,7 @@ func main() {
 	}
 
 	req := responses.Request{
-		Model: models.GPT5,
+		Model: models.GPT5Mini,
 		Input: "Use calc to compute (2+3)*4.",
 		Tools: []string{"calc"},
 	}

--- a/examples/responses/tools/custom/lark/main.go
+++ b/examples/responses/tools/custom/lark/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/unkn0wncode/openai"
+	"github.com/unkn0wncode/openai/models"
+	"github.com/unkn0wncode/openai/responses"
+	"github.com/unkn0wncode/openai/tools"
+)
+
+func main() {
+	token := os.Getenv("OPENAI_API_KEY")
+	if token == "" {
+		panic("set OPENAI_API_KEY env var")
+	}
+
+	client := openai.NewClient(token)
+
+	larkFormat := &tools.CustomToolFormat{
+		Type:       "grammar",
+		Syntax:     "lark",
+		Definition: "start: expr\n?expr: term ((\"+\"|\"-\") term)*\n?term: factor ((\"*\"|\"/\") factor)*\n?factor: NUMBER | \"(\" expr \")\"\n%import common.NUMBER\n%import common.WS\n%ignore WS",
+	}
+
+	if err := client.Config().Tools.RegisterTool(tools.Tool{
+		Type:        "custom",
+		Name:        "calc",
+		Description: "Evaluates arithmetic expressions.",
+		Format:      larkFormat,
+		Custom: func(input string) (string, error) {
+			return fmt.Sprintf("evaluated: %s", input), nil
+		},
+	}); err != nil {
+		panic(err)
+	}
+
+	req := responses.Request{
+		Model: models.GPT5,
+		Input: "Use calc to compute (2+3)*4.",
+		Tools: []string{"calc"},
+	}
+
+	resp, err := client.Responses.Send(&req)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Response ID:", resp.ID)
+	fmt.Println(resp.JoinedTexts())
+}

--- a/examples/responses/tools/custom/regex/main.go
+++ b/examples/responses/tools/custom/regex/main.go
@@ -30,6 +30,7 @@ func main() {
 		Description: "Executes a constrained SQL SELECT statement.",
 		Format:      regexFormat,
 		Custom: func(input string) (string, error) {
+			fmt.Println("Called tool with input:", input)
 			return fmt.Sprintf("ran: %s", input), nil
 		},
 	}); err != nil {
@@ -37,7 +38,7 @@ func main() {
 	}
 
 	req := responses.Request{
-		Model: models.GPT5,
+		Model: models.GPT5Mini,
 		Input: "Use sql_runner to select user_name from users where id=1;",
 		Tools: []string{"sql_runner"},
 	}

--- a/examples/responses/tools/custom/regex/main.go
+++ b/examples/responses/tools/custom/regex/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/unkn0wncode/openai"
+	"github.com/unkn0wncode/openai/models"
+	"github.com/unkn0wncode/openai/responses"
+	"github.com/unkn0wncode/openai/tools"
+)
+
+func main() {
+	token := os.Getenv("OPENAI_API_KEY")
+	if token == "" {
+		panic("set OPENAI_API_KEY env var")
+	}
+
+	client := openai.NewClient(token)
+
+	regexFormat := &tools.CustomToolFormat{
+		Type:       "grammar",
+		Syntax:     "regex",
+		Definition: "(?s)^SELECT\\s+.+\\s+FROM\\s+\\w+(\\s+WHERE\\s+.+)?;?$",
+	}
+
+	if err := client.Config().Tools.RegisterTool(tools.Tool{
+		Type:        "custom",
+		Name:        "sql_runner",
+		Description: "Executes a constrained SQL SELECT statement.",
+		Format:      regexFormat,
+		Custom: func(input string) (string, error) {
+			return fmt.Sprintf("ran: %s", input), nil
+		},
+	}); err != nil {
+		panic(err)
+	}
+
+	req := responses.Request{
+		Model: models.GPT5,
+		Input: "Use sql_runner to select user_name from users where id=1;",
+		Tools: []string{"sql_runner"},
+	}
+
+	resp, err := client.Responses.Send(&req)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Response ID:", resp.ID)
+	fmt.Println(resp.JoinedTexts())
+}

--- a/examples/responses/tools/web_search/main.go
+++ b/examples/responses/tools/web_search/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/unkn0wncode/openai"
 	"github.com/unkn0wncode/openai/models"
@@ -17,6 +18,7 @@ func main() {
 	}
 
 	client := openai.NewClient(token)
+	client.Config().HTTPClient.Timeout = 60 * time.Second
 
 	if err := client.Tools().RegisterTool(tools.Tool{Type: "web_search"}); err != nil {
 		panic(err)

--- a/internal/inresponses/client.go
+++ b/internal/inresponses/client.go
@@ -456,7 +456,7 @@ func (c *Client) Send(req *responses.Request) (*responses.Response, error) {
 			switch {
 			case err == nil:
 			case errors.Is(err, tools.ErrDoNotRespond):
-				// Here we return ID despite error
+				// Here we return ID despite error because this error indicates intended behavior
 				return resp, nil
 			default:
 				return nil, fmt.Errorf("failed to execute function '%s': %w", call.Name, err)

--- a/internal/inresponses/client.go
+++ b/internal/inresponses/client.go
@@ -456,6 +456,7 @@ func (c *Client) Send(req *responses.Request) (*responses.Response, error) {
 			switch {
 			case err == nil:
 			case errors.Is(err, tools.ErrDoNotRespond):
+				// here we return ID despite error
 				return resp, nil
 			default:
 				return nil, fmt.Errorf("failed to execute function '%s': %w", call.Name, err)
@@ -478,6 +479,7 @@ func (c *Client) Send(req *responses.Request) (*responses.Response, error) {
 			switch {
 			case err == nil:
 			case errors.Is(err, tools.ErrDoNotRespond):
+				// Tool requested no further model reply. See note above for rationale.
 				return resp, nil
 			default:
 				return nil, fmt.Errorf("failed to execute custom tool '%s': %w", call.Name, err)

--- a/internal/inresponses/client.go
+++ b/internal/inresponses/client.go
@@ -456,7 +456,7 @@ func (c *Client) Send(req *responses.Request) (*responses.Response, error) {
 			switch {
 			case err == nil:
 			case errors.Is(err, tools.ErrDoNotRespond):
-				// here we return ID despite error
+				// Here we return ID despite error
 				return resp, nil
 			default:
 				return nil, fmt.Errorf("failed to execute function '%s': %w", call.Name, err)
@@ -479,7 +479,6 @@ func (c *Client) Send(req *responses.Request) (*responses.Response, error) {
 			switch {
 			case err == nil:
 			case errors.Is(err, tools.ErrDoNotRespond):
-				// Tool requested no further model reply. See note above for rationale.
 				return resp, nil
 			default:
 				return nil, fmt.Errorf("failed to execute custom tool '%s': %w", call.Name, err)

--- a/responses/service.go
+++ b/responses/service.go
@@ -243,6 +243,21 @@ func (r *Response) FunctionCalls() []output.FunctionCall {
 	return functionCalls
 }
 
+// CustomToolCalls returns a slice of CustomToolCall objects from the response.
+func (r *Response) CustomToolCalls() []output.CustomToolCall {
+	if r.ParsedOutputs == nil {
+		r.Parse() // ignored error check here
+	}
+
+	var customFunctionCalls []output.CustomToolCall
+	for _, o := range r.ParsedOutputs {
+		if call, ok := o.(output.CustomToolCall); ok {
+			customFunctionCalls = append(customFunctionCalls, call)
+		}
+	}
+	return customFunctionCalls
+}
+
 // Refusals returns a slice of Refusal objects from the response.
 func (r *Response) Refusals() []string {
 	if r.ParsedOutputs == nil {

--- a/responses/service.go
+++ b/responses/service.go
@@ -62,6 +62,8 @@ type Content interface {
 		output.WebSearchCall |
 		output.FunctionCall |
 		output.FunctionCallOutput |
+		output.CustomToolCall |
+		output.CustomToolCallOutput |
 		output.Reasoning |
 		input.ItemReference
 }
@@ -332,6 +334,8 @@ func ForceToolChoice(toolType string, name string) json.RawMessage {
 	switch toolType {
 	case "function":
 		return json.RawMessage(fmt.Sprintf(`{"type": "function", "name": "%s"}`, name))
+	case "custom":
+		return json.RawMessage(fmt.Sprintf(`{"type": "custom", "name": "%s"}`, name))
 	case "file_search":
 		return json.RawMessage(`{"type": "file_search"}`)
 	case "web_search", "web_search_preview":

--- a/responses/streaming/types.go
+++ b/responses/streaming/types.go
@@ -141,6 +141,10 @@ func (a *Any) Unmarshal() (any, error) {
 		return unmarshalToType[ResponseReasoningSummaryDelta](a)
 	case "response.reasoning_summary.done":
 		return unmarshalToType[ResponseReasoningSummaryDone](a)
+	case "response.custom_tool_call_input.delta":
+		return unmarshalToType[ResponseCustomToolCallInputDelta](a)
+	case "response.custom_tool_call_input.done":
+		return unmarshalToType[ResponseCustomToolCallInputDone](a)
 	case "error":
 		return unmarshalToType[Error](a)
 	default:
@@ -368,8 +372,16 @@ type (
 			Text string `json:"text"`
 		} `json:"delta"`
 	}
-	ResponseReasoningSummaryDone ResponseReasoningSummaryTextDone // same fields // response.reasoning_summary.done
-	Error                        struct {                         // error
+	ResponseReasoningSummaryDone     ResponseReasoningSummaryTextDone // same fields // response.reasoning_summary.done
+	ResponseCustomToolCallInputDelta struct {                         // response.custom_tool_call_input.delta
+		OutputItemReference
+		Delta string `json:"delta"`
+	}
+	ResponseCustomToolCallInputDone struct { // response.custom_tool_call_input.done
+		OutputItemReference
+		Input string `json:"input"`
+	}
+	Error struct { // error
 		BaseEvent
 		Message string  `json:"message"`
 		Code    string  `json:"code"`


### PR DESCRIPTION
This PR adds support for custom tools:

## Changes
- **Custom Tool Examples**:
  - `auto`: Automatic tool selection and execution
  - `lark`: Lark-specific tool integration  
  - `regex`: Regular expression-based tool functionality

- **Core Improvements**:
  - function call handling in 
  - output processing in 
  - response service and streaming types
  - internal response client

## Testing
To be added.